### PR TITLE
feat: ScrollProductCartView 생성

### DIFF
--- a/SamsungStoreApp/Controller/ViewController+Delegate.swift
+++ b/SamsungStoreApp/Controller/ViewController+Delegate.swift
@@ -12,7 +12,7 @@ import UIKit
 extension ViewController: CategoryTabViewDelegate, ProductPageViewDelegate {
   func didTapCategoryButton(selectedCategoryIndex: Int) {
     let selectedItems = categories[selectedCategoryIndex].items
-    productPageView.configure(with: selectedItems)
+    scrollProductCartView.productPageView.configure(with: selectedItems)
   }
   
   func productPageView(_ view: ProductPageView, didSelect product: ProductItem) {

--- a/SamsungStoreApp/Controller/ViewController.swift
+++ b/SamsungStoreApp/Controller/ViewController.swift
@@ -18,10 +18,7 @@ final class ViewController: UIViewController {
   
   private let mainView = UIView()
   private let categoryTabView = CategoryTabView()
-  
-  let productPageView = ProductPageView()
-  private let cartView = CartView()
-  
+  let scrollProductCartView = ScrollProductCartView()
   private let summaryView = CartSummaryView()
   private let bottomView = BottomView()
   
@@ -39,14 +36,14 @@ final class ViewController: UIViewController {
   private func setupUI() {
     view.backgroundColor = .systemBackground
     view.addSubview(mainView)
-      
-    for item in [categoryTabView, productPageView, cartView, summaryView, bottomView] {
+    
+    for item in [categoryTabView, scrollProductCartView, summaryView, bottomView] {
       mainView.addSubview(item)
     }
-      
+    
     categoryTabView.delegate = self
-    productPageView.delegate = self
-    cartView.delegate = self
+    scrollProductCartView.productPageView.delegate = self
+    scrollProductCartView.cartView.delegate = self
   }
     
   private func setupLayout() {
@@ -58,19 +55,11 @@ final class ViewController: UIViewController {
       $0.top.leading.trailing.equalToSuperview()
       $0.height.equalTo(65)
     }
-      
-    productPageView.snp.makeConstraints {
+    
+    scrollProductCartView.snp.makeConstraints {
       $0.top.equalTo(categoryTabView.snp.bottom)
       $0.leading.trailing.equalToSuperview()
-      //$0.bottom.equalTo(cartView.snp.top)
-      $0.height.equalTo(436)
-    }
-      
-    cartView.snp.makeConstraints {
-      $0.leading.trailing.equalToSuperview()
       $0.bottom.equalTo(summaryView.snp.top)
-      $0.top.equalTo(productPageView.snp.bottom)
-      //$0.height.equalTo(200)
     }
       
     summaryView.snp.makeConstraints {
@@ -101,7 +90,7 @@ final class ViewController: UIViewController {
             })?.items
           {
             print("✅ 불러온 카테고리 수: \(loadedCategories.count)")
-            self.productPageView.configure(with: defaultItems)
+            self.scrollProductCartView.productPageView.configure(with: defaultItems)
           }
         }
       case let .failure(error):
@@ -114,7 +103,7 @@ final class ViewController: UIViewController {
   func updateCartView() {
     let totalCount = cartItems.reduce(0) { $0 + $1.count }
     let totalPrice = cartItems.reduce(0) { $0 + ($1.price * $1.count) }
-    cartView.reload(with: cartItems, totalCount: totalCount, totalPrice: totalPrice)
+    scrollProductCartView.cartView.reload(with: cartItems, totalCount: totalCount, totalPrice: totalPrice)
     summaryView.configure(itemCount: totalCount, totalPrice: totalPrice)
   }
 }

--- a/SamsungStoreApp/Controller/ViewController.swift
+++ b/SamsungStoreApp/Controller/ViewController.swift
@@ -18,8 +18,10 @@ final class ViewController: UIViewController {
   
   private let mainView = UIView()
   private let categoryTabView = CategoryTabView()
+  
   let productPageView = ProductPageView()
   private let cartView = CartView()
+  
   private let summaryView = CartSummaryView()
   private let bottomView = BottomView()
   
@@ -54,19 +56,21 @@ final class ViewController: UIViewController {
       
     categoryTabView.snp.makeConstraints {
       $0.top.leading.trailing.equalToSuperview()
-      // $0.height.equalTo(76) // 얘가 범근님 뷰컨엔 없음
+      $0.height.equalTo(65)
     }
       
     productPageView.snp.makeConstraints {
       $0.top.equalTo(categoryTabView.snp.bottom)
       $0.leading.trailing.equalToSuperview()
-      $0.bottom.equalTo(cartView.snp.top)
+      //$0.bottom.equalTo(cartView.snp.top)
+      $0.height.equalTo(436)
     }
       
     cartView.snp.makeConstraints {
       $0.leading.trailing.equalToSuperview()
       $0.bottom.equalTo(summaryView.snp.top)
-      $0.height.equalTo(200)
+      $0.top.equalTo(productPageView.snp.bottom)
+      //$0.height.equalTo(200)
     }
       
     summaryView.snp.makeConstraints {

--- a/SamsungStoreApp/View/CartView/CartView.swift
+++ b/SamsungStoreApp/View/CartView/CartView.swift
@@ -70,9 +70,9 @@ final class CartView: UIView {
   // tableContainerView 제약조건
   private func setupTableContainerViewLayout() {
     tableContainerView.snp.makeConstraints {
-      $0.top.equalTo(safeAreaLayoutGuide)
+      $0.top.bottom.equalTo(safeAreaLayoutGuide)
       $0.leading.trailing.equalToSuperview().inset(12)
-      $0.height.equalTo(176)
+//      $0.height.equalTo(150)
     }
   }
 

--- a/SamsungStoreApp/View/CategoryTabView/CategoryTabView.swift
+++ b/SamsungStoreApp/View/CategoryTabView/CategoryTabView.swift
@@ -61,7 +61,7 @@ class CategoryTabView: UIView {
     
     categoryStackView.snp.makeConstraints {
       $0.top.bottom.equalTo(categoryScrollView.frameLayoutGuide).inset(16)
-      $0.leading.trailing.equalTo(categoryScrollView.contentLayoutGuide).inset(24)
+      $0.leading.trailing.equalTo(categoryScrollView.contentLayoutGuide).inset(16)
     }
   }
   

--- a/SamsungStoreApp/View/MenuCollectionView/ProductPageCell.swift
+++ b/SamsungStoreApp/View/MenuCollectionView/ProductPageCell.swift
@@ -10,41 +10,41 @@ import UIKit
 
 final class ProductPageCell: UICollectionViewCell {
   // MARK: - UI 컴포넌트
-
+  
   private let verticalStack = UIStackView() // 수직 스택
   private var cells: [ProductGridCell] = []
   
   // MARK: - 핸들러
   
   var tapHandler: ((ProductItem) -> Void)?
-
+  
   // MARK: - 초기화
-
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     setupUI()
     setupLayout()
   }
-
+  
   @available(*, unavailable)
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-
+  
   // MARK: - UI 세팅
-
+  
   private func setupUI() {
     verticalStack.axis = .vertical
-    verticalStack.spacing = 24
+    verticalStack.spacing = 16
     verticalStack.distribution = .fillEqually
     contentView.addSubview(verticalStack)
-
+    
     for _ in 0..<2 {
       let rowStack = UIStackView()
       rowStack.axis = .horizontal
-      rowStack.spacing = 24
+      rowStack.spacing = 16
       rowStack.distribution = .fillEqually
-
+      
       for _ in 0..<2 {
         let grid = ProductGridCell()
         grid.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(cellTapped(_:))))
@@ -54,13 +54,14 @@ final class ProductPageCell: UICollectionViewCell {
       verticalStack.addArrangedSubview(rowStack)
     }
   }
-
+  
   private func setupLayout() {
     verticalStack.snp.makeConstraints {
-      $0.edges.equalToSuperview().inset(24)
+      $0.top.bottom.equalToSuperview().inset(8)
+      $0.leading.trailing.equalToSuperview().inset(16)
     }
   }
-
+  
   // MARK: - 구성
   
   func configure(with products: [ProductItem]) {
@@ -70,33 +71,33 @@ final class ProductPageCell: UICollectionViewCell {
         cell.product = products[index]
       } else {
         cell.isHidden = true
-        cell.product = nil //
+        cell.product = nil
       }
     }
     
     for (rowIndex, rowStack) in verticalStack.arrangedSubviews.enumerated() {
-        guard let rowStack = rowStack as? UIStackView else { continue }
-
-        // 먼저 기존 spacer 뷰가 있다면 제거
-        rowStack.arrangedSubviews
-          .filter { !($0 is ProductGridCell) }
-          .forEach { $0.removeFromSuperview() }
-
-        // row별 유효 셀 개수 계산
-        let startIndex = rowIndex * 2
-        let endIndex = min(startIndex + 2, products.count)
-        let visibleCount = endIndex - startIndex
-
-        if visibleCount == 1 {
-          // 한 셀만 있을 경우, 나머지 공간 채우기용 UIView 추가
-          let spacer = UIView()
-          rowStack.addArrangedSubview(spacer)
-        }
+      guard let rowStack = rowStack as? UIStackView else { continue }
+      
+      // 먼저 기존 spacer 뷰가 있다면 제거
+      rowStack.arrangedSubviews
+        .filter { !($0 is ProductGridCell) }
+        .forEach { $0.removeFromSuperview() }
+      
+      // row별 유효 셀 개수 계산
+      let startIndex = rowIndex * 2
+      let endIndex = min(startIndex + 2, products.count)
+      let visibleCount = endIndex - startIndex
+      
+      if visibleCount == 1 {
+        // 한 셀만 있을 경우, 나머지 공간 채우기용 UIView 추가
+        let spacer = UIView()
+        rowStack.addArrangedSubview(spacer)
       }
+    }
   }
   
   // MARK: - 액션
-
+  
   @objc private func cellTapped(_ sender: UITapGestureRecognizer) {
     guard let cell = sender.view as? ProductGridCell,
           let product = cell.product else { return }

--- a/SamsungStoreApp/View/ScrollProductCartView.swift
+++ b/SamsungStoreApp/View/ScrollProductCartView.swift
@@ -1,0 +1,65 @@
+//
+//  ScrollProductCartView.swift
+//  SamsungStoreApp
+//
+//  Created by 김우성 on 6/30/25.
+//
+
+import SnapKit
+import UIKit
+
+// MARK: - ScrollProductCartView
+
+final class ScrollProductCartView: UIScrollView {
+  
+  // MARK: - UI 컴포넌트
+  
+  let stackView = UIStackView()
+  let productPageView = ProductPageView()
+  let cartView = CartView()
+  
+  // MARK: - 초기화
+  
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+    setupLayout()
+  }
+  
+  @available(*, unavailable)
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  // MARK: - UI 세팅
+  
+  private func setupUI() {
+    addSubview(stackView)
+    stackView.axis = .vertical
+    stackView.spacing = 0
+    
+    for item in [productPageView, cartView] {
+      stackView.addArrangedSubview(item)
+    }
+  }
+  
+  private func setupLayout() {
+    stackView.snp.makeConstraints {
+      $0.edges.equalToSuperview()
+      $0.width.equalToSuperview() // 중요함
+    }
+    
+    productPageView.snp.makeConstraints {
+      $0.top.equalToSuperview()
+      $0.leading.trailing.equalToSuperview()
+      $0.height.equalTo(436)
+    }
+    
+    cartView.snp.makeConstraints {
+      $0.top.equalTo(productPageView.snp.bottom)
+      $0.leading.trailing.equalToSuperview()
+      $0.bottom.equalToSuperview()
+      $0.height.equalTo(200) // 컨텐츠 길이에 따라 유동적으로 바뀌게 하시려면 지울 필요가 있습니다
+    }
+  }
+}


### PR DESCRIPTION
# 변경점
ViewController의 ProductPageView와 CartView를 함께 상하 스크롤이 가능하도록, 
- ScrollProductCartView를 생성
- 그 안에 StackView
- 그리고 그 안에 ProductPageView와 CartView 이관. 
- 파일도 분리했습니다.

### -> 스크롤 속에 또 스크롤이 있는 구조가 되어, 광용님의 건드림이 필요합니다

## 참고
```swift
cartView.snp.makeConstraints {
      $0.top.equalTo(productPageView.snp.bottom)
      $0.leading.trailing.equalToSuperview()
      $0.bottom.equalToSuperview()
      $0.height.equalTo(200) // 컨텐츠 길이에 따라 cartView 높이가 유동적으로 바뀌게 하시려면 제거
```

| 아이폰 16 프로 맥스 | 아이폰 13 SE |
|--------|--------|
| ![Simulator Screen Recording - iPhone 16 Pro Max - 2025-06-30 at 12 43 05](https://github.com/user-attachments/assets/56bad3f7-7e4b-4f60-8d18-d4414dd873a1) | ![Simulator Screen Recording - iPhone SE (3rd generation) - 2025-06-30 at 12 41 57](https://github.com/user-attachments/assets/674527ec-dca1-4a56-b578-e8e9cbdf56eb) |