### PR TITLE
[Feat] 하단 버튼 기능 추가

### DIFF
--- a/SamsungStoreApp/Controller/ViewController+Delegate.swift
+++ b/SamsungStoreApp/Controller/ViewController+Delegate.swift
@@ -28,7 +28,7 @@ extension ViewController: CategoryTabViewDelegate, ProductPageViewDelegate {
   }
 }
 
-extension ViewController: CartViewDelegate {
+extension ViewController: CartViewDelegate, BottomViewDelegate {
   func cartView(_ cartView: CartView, didTapDeleteAt index: Int) {
     cartItems.remove(at: index)
     updateCartView()
@@ -37,5 +37,28 @@ extension ViewController: CartViewDelegate {
   func cartView(_ cartView: CartView, didChangeCountAt index: Int, to newCount: Int) {
     cartItems[index].count = newCount
     updateCartView()
+  }
+  
+  // 주문 전체 취소
+  func didTapClearButton() {
+    showAlert(title: "주문 취소", message: "주문 내역을 모두 삭제하시겠습니까?") {
+      self.cartItems.removeAll()
+      self.updateCartView()
+    }
+  }
+  
+  func didTapPayButton() {
+    
+  }
+  
+  private func showAlert(title: String, message: String, onConfirm: @escaping () -> Void) {
+    let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+    
+    alert.addAction(UIAlertAction(title: "아니오", style: .cancel, handler: nil))
+    alert.addAction(UIAlertAction(title: "네", style: .destructive, handler: { _ in
+      onConfirm()
+    }))
+    
+    present(alert, animated: true)
   }
 }

--- a/SamsungStoreApp/Controller/ViewController+Delegate.swift
+++ b/SamsungStoreApp/Controller/ViewController+Delegate.swift
@@ -42,13 +42,25 @@ extension ViewController: CartViewDelegate, BottomViewDelegate {
   // 주문 전체 취소
   func didTapClearButton() {
     showAlert(title: "주문 취소", message: "주문 내역을 모두 삭제하시겠습니까?") {
+      // 장바구니 초기화
       self.cartItems.removeAll()
       self.updateCartView()
     }
   }
   
+  // 주문 결제
   func didTapPayButton() {
-    
+    showAlert(title: "주문 결제", message: "해당 상품을 결제하시겠습니까?") {
+      // 장바구니 초기화, 카테고리 첫번째로 이동
+      self.cartItems.removeAll()
+      self.updateCartView()
+      
+      self.categoryTabView.updateButtonState(index: 0)
+      let selectedItems = self.categories[0].items
+      self.productPageView.configure(with: selectedItems)
+      
+      self.showSuccessAlert()
+    }
   }
   
   private func showAlert(title: String, message: String, onConfirm: @escaping () -> Void) {
@@ -60,5 +72,18 @@ extension ViewController: CartViewDelegate, BottomViewDelegate {
     }))
     
     present(alert, animated: true)
+  }
+  
+  // 결제 완료 안내
+  private func showSuccessAlert() {
+    let successAlert = UIAlertController(
+      title: "결제 완료",
+      message: "주문하신 내역이 결제 완료되었습니다.",
+      preferredStyle: .alert
+    )
+    
+    successAlert.addAction(UIAlertAction(title: "확인", style: .default))
+    
+    present(successAlert, animated: true)
   }
 }

--- a/SamsungStoreApp/Controller/ViewController.swift
+++ b/SamsungStoreApp/Controller/ViewController.swift
@@ -113,5 +113,6 @@ final class ViewController: UIViewController {
     let totalPrice = cartItems.reduce(0) { $0 + ($1.price * $1.count) }
     cartView.reload(with: cartItems, totalCount: totalCount, totalPrice: totalPrice)
     summaryView.configure(itemCount: totalCount, totalPrice: totalPrice)
+    bottomView.updateButtonsEnabled(totalCount != 0)
   }
 }

--- a/SamsungStoreApp/Controller/ViewController.swift
+++ b/SamsungStoreApp/Controller/ViewController.swift
@@ -45,6 +45,7 @@ final class ViewController: UIViewController {
     categoryTabView.delegate = self
     productPageView.delegate = self
     cartView.delegate = self
+    bottomView.delegate = self
   }
     
   private func setupLayout() {

--- a/SamsungStoreApp/Controller/ViewController.swift
+++ b/SamsungStoreApp/Controller/ViewController.swift
@@ -17,7 +17,7 @@ final class ViewController: UIViewController {
   private let dataService = DataService()
   
   private let mainView = UIView()
-  private let categoryTabView = CategoryTabView()
+  let categoryTabView = CategoryTabView()
   let productPageView = ProductPageView()
   private let cartView = CartView()
   private let summaryView = CartSummaryView()

--- a/SamsungStoreApp/View/BottomView/BottomView.swift
+++ b/SamsungStoreApp/View/BottomView/BottomView.swift
@@ -20,7 +20,7 @@ class BottomView: UIView {
   // 버튼 생성
   private let clearButton: BottomButton = .init(title: "전체 취소", type: .clear, fontSize: 18)
   private let payButton: BottomButton = .init(title: "결제하기", type: .pay, fontSize: 18)
-
+  
   /// 버튼들을 수평 정렬할 스택뷰
   private lazy var bottomButtonStack: UIStackView = {
     let stackView = UIStackView(arrangedSubviews: [clearButton, payButton])
@@ -30,21 +30,21 @@ class BottomView: UIView {
     stackView.distribution = .fillEqually
     return stackView
   }()
-
+  
   // MARK: - Initializer
-
+  
   override init(frame: CGRect) {
     super.init(frame: frame)
     setupUI()
   }
-
+  
   @available(*, unavailable)
   required init?(coder _: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-
+  
   // MARK: - UI 구성
-
+  
   private func setupUI() {
     addSubview(bottomButtonStack)
     bottomButtonStack.snp.makeConstraints {
@@ -52,6 +52,7 @@ class BottomView: UIView {
       $0.top.bottom.equalToSuperview()
     }
     
+    updateButtonsEnabled(false)
     clearButton.setAction(self, action: #selector(clearButtonTapped))
     payButton.setAction(self, action: #selector(payButtonTapped))
   }
@@ -63,5 +64,13 @@ class BottomView: UIView {
   
   @objc private func payButtonTapped() {
     delegate?.didTapPayButton()
+  }
+  
+  // MARK: - 버튼 활성화/비활성화 제어
+  func updateButtonsEnabled(_ isEnabled: Bool) {
+    [clearButton, payButton].forEach {
+      $0.isEnabled = isEnabled
+      $0.alpha = isEnabled ? 1.0 : 0.3
+    }
   }
 }

--- a/SamsungStoreApp/View/BottomView/BottomView.swift
+++ b/SamsungStoreApp/View/BottomView/BottomView.swift
@@ -6,9 +6,17 @@
 //
 
 import UIKit
+import SnapKit
+
+protocol BottomViewDelegate: AnyObject {
+  func didTapClearButton()
+  func didTapPayButton()
+}
 
 /// 하단 결제/취소 버튼 뷰
 class BottomView: UIView {
+  weak var delegate: BottomViewDelegate?
+  
   // 버튼 생성
   private let clearButton: BottomButton = .init(title: "전체 취소", type: .clear, fontSize: 18)
   private let payButton: BottomButton = .init(title: "결제하기", type: .pay, fontSize: 18)
@@ -43,5 +51,17 @@ class BottomView: UIView {
       $0.leading.trailing.equalToSuperview().inset(24)
       $0.top.bottom.equalToSuperview()
     }
+    
+    clearButton.setAction(self, action: #selector(clearButtonTapped))
+    payButton.setAction(self, action: #selector(payButtonTapped))
+  }
+  
+  // MARK: - 버튼 액션 핸들러
+  @objc private func clearButtonTapped() {
+    delegate?.didTapClearButton()
+  }
+  
+  @objc private func payButtonTapped() {
+    delegate?.didTapPayButton()
   }
 }


### PR DESCRIPTION
## 변경 사항
- 전체 취소 버튼 기능
  - 취소 확인 알럿창 추가
  - 취소 시 장바구니 초기화
- 결제 버튼 기능
  - 결제 확인 알럿창 추가
  - 결제 시 장바구니 초기화 및 첫번째 카테고리로 이동
- 취소 및 결제 버튼 활성화 제어 기능
  - 장바구니에 아이템 없을 경우 비활성화되도록

## 실행 화면
|취소 확인 알럿창|결제 확인 알럿창|하단 버튼 비활성화|
|---|---|---|
|<img width="363" alt="image" src="https://github.com/user-attachments/assets/b07b05f8-5456-40c2-a93e-b8c3ef7a2da2" />|<img width="363" alt="image" src="https://github.com/user-attachments/assets/27b94658-a9e1-45b1-9de1-df4ad49e15cf" />|<img width="363" alt="image" src="https://github.com/user-attachments/assets/6d173991-0fc6-4b20-98e6-50fa9d7e9095" />|